### PR TITLE
DENG-6172: Expose DAG tags in Airflow metrics endpoint

### DIFF
--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -493,8 +493,6 @@ class MetricsCollector(object):
                 dag.end_date - dag.start_date
             ).total_seconds()
             dag_duration.add_metric([dag.dag_id], dag_duration_value)
-
-
         yield dag_duration
 
         # Scheduler Metrics

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -200,7 +200,7 @@ def get_task_state_info():
             )
             .join(DagModel, DagModel.dag_id == task_status_query.c.dag_id)
             .filter(
-                #DagModel.is_active == True,  # noqa
+                DagModel.is_active == True,  # noqa
                 DagModel.is_paused == False,
             )
             .outerjoin(

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -34,6 +34,12 @@ def session_scope(session):
         session.close()
 
 
+with session_scope(Session) as session:
+    Base = declarative_base(session.get_bind())
+    class GapDagTag(Base):
+        __tablename__ = 'gap_dag_tag'
+        __table_args__ = {'autoload': True}
+
 ######################
 # DAG Related Metrics
 ######################
@@ -43,6 +49,7 @@ def get_dag_state_info():
     """Number of DAG Runs with particular state."""
     min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
     with session_scope(Session) as session:
+
         dag_status_query = (
             session.query(
                 DagTag.name,
@@ -67,12 +74,18 @@ def get_dag_state_info():
                 dag_status_query.c.state,
                 dag_status_query.c.count,
                 DagModel.owners,
+                GapDagTag.cadence,
+                GapDagTag.severerity,
+                GapDagTag.alert_target,
+                GapDagTag.instant_slack_alert,
+                GapDagTag.alert_classification,
             )
             .join(DagModel, DagModel.dag_id == dag_status_query.c.dag_id)
             .filter(
                 DagModel.is_active == True,  # noqa
                 DagModel.is_paused == False,
             )
+            .outerjoin(GapDagTag, GapDagTag.dag_id == dag_status_query.c.dag_id)
             .all()
         )
 
@@ -179,11 +192,22 @@ def get_task_state_info():
                 task_status_query.c.state,
                 task_status_query.c.value,
                 DagModel.owners,
+                GapDagTag.cadence,
+                GapDagTag.severerity,
+                GapDagTag.alert_target,
+                GapDagTag.instant_slack_alert,
+                GapDagTag.alert_classification,
             )
             .join(DagModel, DagModel.dag_id == task_status_query.c.dag_id)
             .filter(
-                DagModel.is_active == True,  # noqa
+                #DagModel.is_active == True,  # noqa
                 DagModel.is_paused == False,
+            )
+            .outerjoin(
+                GapDagTag,
+                (GapDagTag.dag_id == task_status_query.c.dag_id)
+                &
+                (GapDagTag.task_id == task_status_query.c.task_id),
             )
             .all()
         )
@@ -387,12 +411,24 @@ class MetricsCollector(object):
         t_state = GaugeMetricFamily(
             "airflow_task_status",
             "Shows the number of task instances with particular status",
-            labels=["tag", "dag_id", "task_id", "owner", "status"],
+            labels=["tag", "dag_id", "task_id", "owner", "status", "cadence", "severity",
+                "alert_target", "instant_slack_alert", "alert_classification"],
         )
         for task in task_info:
             t_state.add_metric(
-                [task.name or "none", task.dag_id, task.task_id, task.owners, task.state or "none"],
-                task.value,
+                [
+                    task.name or "none",
+                    task.dag_id,
+                    task.task_id,
+                    task.owners,
+                    task.state or "none",
+                    task.cadence or "none",
+                    task.severerity or "none",
+                    task.alert_target or "none",
+                    task.instant_slack_alert or "none",
+                    task.alert_classification or "none"
+                ],
+                task.value
             )
         yield t_state
 
@@ -427,10 +463,24 @@ class MetricsCollector(object):
         d_state = GaugeMetricFamily(
             "airflow_dag_status",
             "Shows the number of dag starts with this status",
-            labels=["tag", "dag_id", "owner", "status"],
+            labels=["tag", "dag_id", "owner", "status", "cadence", "severity",
+                "alert_target", "instant_slack_alert", "alert_classification"],
         )
         for dag in dag_info:
-            d_state.add_metric([dag.name or "none", dag.dag_id, dag.owners, dag.state], dag.count)
+            d_state.add_metric(
+                [
+                    dag.name or "none",
+                    dag.dag_id,
+                    dag.owners,
+                    dag.state,
+                    dag.cadence or "none",
+                    dag.severerity or "none",
+                    dag.alert_target or "none",
+                    dag.instant_slack_alert or "none",
+                    dag.alert_classification or "none"
+                ],
+                dag.count
+            )
         yield d_state
 
         dag_duration = GaugeMetricFamily(
@@ -443,6 +493,8 @@ class MetricsCollector(object):
                 dag.end_date - dag.start_date
             ).total_seconds()
             dag_duration.add_metric([dag.dag_id], dag_duration_value)
+
+
         yield dag_duration
 
         # Scheduler Metrics


### PR DESCRIPTION
# Summary [DENG-6172](https://openmail.atlassian.net/browse/DENG-6172)

1. Add new table.
2. Add info into dag_status and task_status.

# Deployment Instructions

1. Create table

```
create table gap_dag_tag (
    dag_id varchar(250)
    ,task_id varchar(250)
    ,cadence varchar(250)
    ,severerity varchar(250)
    ,alert_target varchar(250)
    ,instant_slack_alert varchar(250)
    ,alert_classification varchar(250)
    ,primary key (dag_id, task_id)
);
```

2. Set new version
3. Update airflow requirements.txt in OpenMail repo
4. Merge
5. push_airflow_prod