### PR TITLE
DENG-6172-2: DAG TAG Missing Import

### DIFF
--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -16,6 +16,7 @@ from flask_admin import BaseView, expose
 from prometheus_client import generate_latest, REGISTRY
 from prometheus_client.core import GaugeMetricFamily
 from sqlalchemy import and_, func
+from sqlalchemy.ext.declarative import declarative_base
 
 from airflow_prometheus_exporter.xcom_config import load_xcom_config
 


### PR DESCRIPTION
# Summary

1. Missing import declarative_base

# Deployment Instructions

1. Tag v1.1.1
2. Update airflow requirements.etl.txt