### PR TITLE
DENG-6683: SLA for Hourly, Intraday, and Triggered

### DIFF
--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -53,7 +53,7 @@ with session_scope(Session) as session:
         alert_target = Column(String)
         alert_external_classification = Column(String)
         alert_report_classification = Column(String)
-        sla_interval = Column(Float)
+        sla_interval = Column(String)
         sla_time = Column(String)
         group_pagerduty = Column(String)
         group_business_line = Column(String)
@@ -389,12 +389,12 @@ seconds_per_unit = {
 }
 sla_interval_pattern = re.compile("[ ]*([0-9]+).*(s|m|h|d|w)[ ]*")
 def convert_to_seconds(sla_interval):
-    match = re.match(sla_interval_pattern, sla_interval.strip())
+    match = re.match(sla_interval_pattern, sla_interval)
     return int(match.group(1)) * seconds_per_unit[match.group(2)] 
 
 def sla_check(sla_interval, sla_time, max_execution_date, cadence):
     now = pendulum.now(TIMEZONE_LA)
-    interval_in_second = convert_to_seconds(interval)
+    interval_in_second = convert_to_seconds(sla_interval)
 
     if sla_time:
         naive_sla_time = dateparser.parse("today " + sla_time)
@@ -440,6 +440,7 @@ def get_sla_miss_dags():
                 DelayAlertMetaData.dag_id,
                 DelayAlertMetaData.sla_interval,
                 DelayAlertMetaData.sla_time,
+                DelayAlertMetaData.cadence,
                 DelayAlertMetaData.severity,
                 DelayAlertMetaData.alert_target,
                 DelayAlertMetaData.alert_external_classification,
@@ -530,6 +531,7 @@ def get_sla_miss_tasks():
                 DelayAlertMetaData.sla_interval,
                 DelayAlertMetaData.sla_time,
                 DelayAlertMetaData.severity,
+                DelayAlertMetaData.cadence,
                 DelayAlertMetaData.alert_target,
                 DelayAlertMetaData.alert_external_classification,
                 DelayAlertMetaData.alert_report_classification,
@@ -580,7 +582,7 @@ def get_sla_miss_tasks():
                 task.sla_interval,
                 task.sla_time,
                 max_execution_date,
-                dag.cadence,
+                task.cadence,
             )
 
             sla_miss_tasks.append(task_metrics)

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -403,12 +403,14 @@ def sla_check(sla_interval, sla_time, max_execution_date, cadence):
         # Usually hourly, intraday
         sla_time = now
         
-    checkpoint = sla_time.timestamp() - interval_in_second
-    if now > sla_time and max_execution_date.timestamp() < checkpoint:
+    checkpoint =  sla_time.timestamp() - interval_in_second
+    sla_miss = max_execution_date.timestamp() < checkpoint
+    if sla_miss and now >= sla_time:
         return True
         
     checkpoint -= interval_in_second
-    if cadence != "triggered" and max_execution_date.timestamp() < checkpoint:
+    sla_miss = max_execution_date.timestamp() < checkpoint
+    if sla_miss and cadence != "triggered":
         # Check for previous successful run if before sla_time in day.
         # Filter out triggered DAGs e.g. PPD
         return True

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -390,7 +390,6 @@ def convert_to_seconds(s):
 
 def sla_check(sla_interval, sla_time, max_execution_date, cadence):
     now = pendulum.now("America/Los_Angeles")
-    interval = "{}d".format(int(sla_interval + 1))
     interval_in_second = convert_to_seconds(interval)
 
     if sla_time:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 apache-airflow==1.10.12
 croniter==0.3.37
 dateparser==1.0.0
-prometheus_client==0.8.0
-pendulum==1.4.4
 importlib_metadata==1.7.0
-numpy==1.18.1
 marshmallow-sqlalchemy==0.23.1
 marshmallow==2.21.0
+numpy==1.18.1
+pendulum==1.4.4
+prometheus_client==0.8.0
+pytimeparse==1.1.8


### PR DESCRIPTION
# Summary [DENG-6683](https://openmail.atlassian.net/browse/DENG-6683)

1. Ability to handle hourly, intraday, and triggered DAGs
2. Add new expressions for sla_interval: 30s, 15m, 2h, 1d, 2w.

# Deployment Instructions

1. Tag v1.2.6
2. Update airflow requirement
3. build_and_deploy_airflow
4. Update existing sla_interval to string format (e.g. 1s, 3m, 5h, 2d, 1w)
5. Alter table delay_alert_metadata.sla_interval to varchar
6. Update delay_alert_metadata table 