### PR TITLE
DATAOPS: Fix SLA Logic

### DIFF
--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -388,16 +388,17 @@ def sla_check(sla_interval, sla_time, max_execution_date, cadence, execution_dat
 
     interval_in_second = pytime_parse(sla_interval)
     checkpoint = sla_datetime - datetime.timedelta(seconds=interval_in_second)
-    if utc_datetime >= sla_datetime and max_execution_date < checkpoint:
-        return True
+    if utc_datetime >= sla_datetime:
+        if max_execution_date < checkpoint:
+            return True
 
-    if cadence != "triggered":
-        # Check the state of previous run before sla_time.
-        # To detect consecutive failed scenario.
-        # Filter out triggered DAGs e.g. PPD
-        for record in execution_dates:
-            if record["execution_date"] <= checkpoint:
-                return record["state"] != "success"
+        if cadence != "triggered":
+            # Check the state of previous run before sla_time.
+            # To detect consecutive failed scenario.
+            # Filter out triggered DAGs e.g. PPD
+            for record in execution_dates:
+                if record["execution_date"] <= checkpoint:
+                    return record["state"] != "success"
 
     return False
 

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -376,26 +376,27 @@ def get_num_queued_tasks():
 def sla_check(sla_interval, sla_time, max_execution_date, cadence, execution_dates):
     utc_datetime = pytz.timezone("UTC").localize(datetime.datetime.utcnow())
     if sla_time:
+        # Convert user defined SLA time to local datetime.
         local_datetime = utc_datetime.astimezone(pytz.timezone(TIMEZONE_LA))
         sla_datetime = pytz.timezone(TIMEZONE_LA).localize(
             datetime.datetime.combine(
                 local_datetime.date(),
-                datetime.datetime.strptime(sla_time, "%H:%M").time()
+                datetime.datetime.strptime(sla_time, "%H:%M").time(),
             )
         )
     else:
+        # If no defined SLA time, meaning we check SLA miss every time.
         sla_datetime = utc_datetime
 
     interval_in_second = pytime_parse(sla_interval)
     checkpoint = sla_datetime - datetime.timedelta(seconds=interval_in_second)
-    if utc_datetime >= sla_datetime:
-        if max_execution_date < checkpoint:
-            return True
 
+    # Check SLA miss when it's SLA time.
+    if utc_datetime >= sla_datetime:
+        return max_execution_date < checkpoint
+
+    # Check SLA miss when it's before SLA time to see the state of previous run.
     if cadence != "triggered":
-        # Check the state of previous run before sla_time.
-        # To detect consecutive failed scenario.
-        # Filter out triggered DAGs e.g. PPD
         for record in execution_dates:
             if record["execution_date"] <= checkpoint:
                 return record["execution_date"] > max_execution_date

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -392,13 +392,13 @@ def sla_check(sla_interval, sla_time, max_execution_date, cadence, execution_dat
         if max_execution_date < checkpoint:
             return True
 
-        if cadence != "triggered":
-            # Check the state of previous run before sla_time.
-            # To detect consecutive failed scenario.
-            # Filter out triggered DAGs e.g. PPD
-            for record in execution_dates:
-                if record["execution_date"] <= checkpoint:
-                    return record["state"] != "success"
+    if cadence != "triggered":
+        # Check the state of previous run before sla_time.
+        # To detect consecutive failed scenario.
+        # Filter out triggered DAGs e.g. PPD
+        for record in execution_dates:
+            if record["execution_date"] <= checkpoint:
+                return record["execution_date"] > max_execution_date
 
     return False
 


### PR DESCRIPTION
# Summary

1. The check inside of `utc_datetime >= sla_datetime` needs to return False if no miss.
2. The check inside of `record["execution_date"] <= checkpoint` needs to be changed to `record["execution_date"] > max_execution_date`. The reason is when I retrieving states from dag_run, the states maybe changed due to re-processing (look back). So it failed to represent the fact. In order to make it right, we check the first run outside of checkpoint against `max_execution_date` which is the latest successful run. If the date time of the run is greater than max_execution_date, meaning the nearest run outside of checkpoint never succeeded.


# Deployment Instructions

1. Merge and tag
2. Update airflow/requirements.etl.txt
3. build_and_deploy_airflow