### PR TITLE
DATAOPS-158: Combine SLA Miss Functions

### DIFF
--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -500,7 +500,7 @@ class MetricsCollector(object):
         )
 
         for alert in get_sla_miss():
-            sla_miss_dags_metric.add_metric(
+            sla_miss_metric.add_metric(
                 [
                     alert["dag_id"],
                     alert["task_id"],

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -16,6 +16,7 @@ from prometheus_client.core import GaugeMetricFamily
 from pytimeparse import parse as pytime_parse
 from sqlalchemy import Column, String, and_, func
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.sql.expression import null
 from sqlalchemy_utcdatetime import UTCDateTime
 
 from airflow.configuration import conf
@@ -270,6 +271,7 @@ def get_sla_miss():
         dag_max_execution_date = (
             session.query(
                 DagRun.dag_id,
+                null().label("task_id"),
                 func.max(DagRun.execution_date).label("execution_date"),
             )
             .join(

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -379,6 +379,10 @@ def get_sla_miss():
                     "insert": insert,
                 }
 
+            # Only report records that missed SLA
+            if sla_miss is False:
+                continue
+
             alert_name = alert.alert_name
             if alert_name is None:
                 alert_name = alert.dag_id

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -31,6 +31,7 @@ RETENTION_TIME = os.environ.get("PROMETHEUS_METRICS_DAYS", 21)
 TIMEZONE = conf.get("core", "default_timezone")
 TIMEZONE_LA = "America/Los_Angeles"
 MISSING = "missing"
+DEFAULT_LINK = "https://openmail.atlassian.net/wiki/spaces/ETL/pages/2132508806/Help"
 
 
 @contextmanager
@@ -45,172 +46,23 @@ def session_scope(session):
 with session_scope(Session) as session:
     Base = declarative_base(session.get_bind())
 
-    class DelayAlertMetaData(Base):
-        __tablename__ = "delay_alert_metadata"
+    class DelayAlertMetadata(Base):
+        __tablename__ = "ddns_delay_alert_metadata"
         __table_args__ = {"autoload": True}
         dag_id = Column(String, primary_key=True)
+
+
+    class DelayAlertAuxiliaryInfo(Base):
+        __tablename__ = "ddns_delay_alert_auxiliary_info"
+        __table_args__ = {"autoload": True}
+        dag_id = Column(String, primary_key=True)
+        task_id = Column(String, primary_key=True)
         latest_successful_run = Column(UTCDateTime)
-
-    class LatestSuccessfulRun(Base):
-        __tablename__ = "ddns_latest_successful_run"
-        __table_args__ = {"autoload": True}
-        dag_id = Column(String, primary_key=True)
-        task_id = Column(String, primary_key=True, nullable=True)
-        execution_date = Column(UTCDateTime)
-
-######################
-# DAG Related Metrics
-######################
-
-
-def get_dag_state_info():
-    """Number of DAG Runs with particular state."""
-    with session_scope(Session) as session:
-        min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
-        dag_status_query = (
-            session.query(
-                DagRun.dag_id, DagRun.state, func.count(DagRun.state).label("count")
-            )
-            .filter(
-                DagRun.execution_date > min_date_to_filter,
-                DagRun.external_trigger == False,
-                DagRun.state.isnot(None),
-            )  # noqa
-            .group_by(DagRun.dag_id, DagRun.state)
-            .subquery()
-        )
-        return (
-            session.query(
-                dag_status_query.c.dag_id,
-                dag_status_query.c.state,
-                dag_status_query.c.count,
-                DagModel.owners,
-                DelayAlertMetaData.cadence,
-                DelayAlertMetaData.severity,
-                DelayAlertMetaData.alert_target,
-                DelayAlertMetaData.alert_external_classification,
-                DelayAlertMetaData.alert_report_classification,
-                DelayAlertMetaData.sla_time,
-            )
-            .join(DagModel, DagModel.dag_id == dag_status_query.c.dag_id)
-            .filter(DagModel.is_active == True, DagModel.is_paused == False)  # noqa
-            .outerjoin(
-                DelayAlertMetaData,
-                DelayAlertMetaData.dag_id == dag_status_query.c.dag_id,
-            )
-            .filter(DelayAlertMetaData.task_id.is_(None))
-            .all()
-        )
-
-
-def get_dag_duration_info():
-    """Duration of successful DAG Runs."""
-    min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
-    with session_scope(Session) as session:
-        max_execution_dt_query = (
-            session.query(
-                DagRun.dag_id, func.max(DagRun.execution_date).label("max_execution_dt")
-            )
-            .join(DagModel, DagModel.dag_id == DagRun.dag_id)
-            .filter(
-                DagModel.is_active == True,  # noqa
-                DagModel.is_paused == False,
-                DagRun.state == State.SUCCESS,
-                DagRun.end_date.isnot(None),
-                DagRun.execution_date > min_date_to_filter,
-            )
-            .group_by(DagRun.dag_id)
-            .subquery()
-        )
-
-        dag_start_dt_query = (
-            session.query(
-                max_execution_dt_query.c.dag_id,
-                max_execution_dt_query.c.max_execution_dt.label("execution_date"),
-                func.min(TaskInstance.start_date).label("start_date"),
-            )
-            .join(
-                TaskInstance,
-                and_(
-                    TaskInstance.dag_id == max_execution_dt_query.c.dag_id,
-                    (
-                        TaskInstance.execution_date
-                        == max_execution_dt_query.c.max_execution_dt  # noqa
-                    ),
-                ),
-            )
-            .filter(
-                TaskInstance.start_date.isnot(None), TaskInstance.end_date.isnot(None)
-            )
-            .group_by(
-                max_execution_dt_query.c.dag_id,
-                max_execution_dt_query.c.max_execution_dt,
-            )
-            .subquery()
-        )
-
-        return (
-            session.query(
-                dag_start_dt_query.c.dag_id,
-                dag_start_dt_query.c.start_date,
-                DagRun.end_date,
-            )
-            .join(
-                DagRun,
-                and_(
-                    DagRun.dag_id == dag_start_dt_query.c.dag_id,
-                    DagRun.execution_date == dag_start_dt_query.c.execution_date,
-                ),
-            )
-            .all()
-        )
 
 
 ######################
 # Task Related Metrics
 ######################
-
-
-def get_task_state_info():
-    """Number of task instances with particular state."""
-    min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
-    with session_scope(Session) as session:
-        task_status_query = (
-            session.query(
-                TaskInstance.dag_id,
-                TaskInstance.task_id,
-                TaskInstance.state,
-                func.count(TaskInstance.dag_id).label("value"),
-            )
-            .group_by(TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.state)
-            .filter(TaskInstance.execution_date > min_date_to_filter)
-            .subquery()
-        )
-        return (
-            session.query(
-                task_status_query.c.dag_id,
-                task_status_query.c.task_id,
-                task_status_query.c.state,
-                task_status_query.c.value,
-                DagModel.owners,
-                DelayAlertMetaData.cadence,
-                DelayAlertMetaData.severity,
-                DelayAlertMetaData.alert_target,
-                DelayAlertMetaData.alert_external_classification,
-                DelayAlertMetaData.alert_report_classification,
-                DelayAlertMetaData.sla_time,
-            )
-            .join(DagModel, DagModel.dag_id == task_status_query.c.dag_id)
-            .filter(DagModel.is_active == True, DagModel.is_paused == False)  # noqa
-            .outerjoin(
-                DelayAlertMetaData,
-                (DelayAlertMetaData.dag_id == task_status_query.c.dag_id)
-                & (DelayAlertMetaData.task_id == task_status_query.c.task_id),  # noqa
-            )
-            .filter(DelayAlertMetaData.task_id.isnot(None))
-            .all()
-        )
-
 
 def get_task_failure_counts():
     """Compute Task Failure Counts."""
@@ -276,51 +128,6 @@ def extract_xcom_parameter(value):
             return {}
 
 
-def get_task_duration_info():
-    """Duration of successful tasks in seconds."""
-    with session_scope(Session) as session:
-        max_execution_dt_query = (
-            session.query(
-                DagRun.dag_id, func.max(DagRun.execution_date).label("max_execution_dt")
-            )
-            .join(DagModel, DagModel.dag_id == DagRun.dag_id)
-            .filter(
-                DagModel.is_active == True,  # noqa
-                DagModel.is_paused == False,
-                DagRun.state == State.SUCCESS,
-                DagRun.end_date.isnot(None),
-            )
-            .group_by(DagRun.dag_id)
-            .subquery()
-        )
-
-        return (
-            session.query(
-                TaskInstance.dag_id,
-                TaskInstance.task_id,
-                TaskInstance.start_date,
-                TaskInstance.end_date,
-                TaskInstance.execution_date,
-            )
-            .join(
-                max_execution_dt_query,
-                and_(
-                    (TaskInstance.dag_id == max_execution_dt_query.c.dag_id),
-                    (
-                        TaskInstance.execution_date
-                        == max_execution_dt_query.c.max_execution_dt  # noqa
-                    ),
-                ),
-            )
-            .filter(
-                TaskInstance.state == State.SUCCESS,
-                TaskInstance.start_date.isnot(None),
-                TaskInstance.end_date.isnot(None),
-            )
-            .all()
-        )
-
-
 ######################
 # Scheduler Related Metrics
 ######################
@@ -379,35 +186,9 @@ def get_num_queued_tasks():
             .count()
         )
 
-def insert_latest_successful_runs(session, insert_dict):
-    for key, execution_date in insert_dict.items():
-        dag_id, task_id = key
-        session.add(LatestSuccessfulRun(
-            dag_id=dag_id,
-            task_id=task_id,
-            execution_date=execution_date,
-        ))
-    session.flush()
-    session.commit()
+def sla_check(sla_interval, sla_time, max_execution_date, cadence, latest_sla_miss_state):
+    utc_datetime = pytz.timezone(TIMEZONE).localize(datetime.datetime.utcnow())
 
-def update_latest_successful_runs(session, update_dict):
-    for key, execution_date in update_dict.items():
-        dag_id, task_id = key
-        if task_id is None:
-            session.query(LatestSuccessfulRun).filter(
-                LatestSuccessfulRun.dag_id == dag_id,
-                LatestSuccessfulRun.task_id.is_(None),
-            ).update({LatestSuccessfulRun.execution_date: execution_date})
-        else:
-            session.query(LatestSuccessfulRun).filter(
-                LatestSuccessfulRun.dag_id == dag_id,
-                LatestSuccessfulRun.task_id == task_id,
-            ).update({LatestSuccessfulRun.execution_date: execution_date})
-    session.flush()
-    session.commit()
-
-def sla_check(sla_interval, sla_time, max_execution_date, cadence, execution_dates):
-    utc_datetime = pytz.timezone("UTC").localize(datetime.datetime.utcnow())
     if sla_time:
         # Convert user defined SLA time to local datetime.
         local_datetime = utc_datetime.astimezone(pytz.timezone(TIMEZONE_LA))
@@ -430,261 +211,182 @@ def sla_check(sla_interval, sla_time, max_execution_date, cadence, execution_dat
 
     # Check SLA miss when it's before SLA time to see the state of previous run.
     if cadence != "triggered":
-        for record in execution_dates:
-            if record <= checkpoint:
-                return record > max_execution_date
+        return latest_sla_miss_state
 
     return False
 
 
-def get_sla_miss_dags():
-    min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
+def upsert_auxiliary_info(session, key, value, insert):
+    dag_id, task_id = key
+    latest_successful_run = value["max_execution_date"]
+    latest_sla_miss_state = value["sla_miss"]
+
+    if insert:
+        session.add(DelayAlertAuxiliaryInfo(
+            dag_id=dag_id,
+            task_id=task_id,
+            latest_successful_run=latest_successful_run,
+            latest_sla_miss_state=latest_sla_miss_state,
+        ))
+    else:
+        session.query(DelayAlertAuxiliaryInfo).filter(
+            DelayAlertAuxiliaryInfo.dag_id == dag_id,
+            DelayAlertAuxiliaryInfo.task_id == task_id,
+        ).update({
+            DelayAlertAuxiliaryInfo.latest_successful_run: latest_successful_run,
+            DelayAlertAuxiliaryInfo.latest_sla_miss_state: latest_sla_miss_state,
+        })
+
+
+def get_sla_miss():
     with session_scope(Session) as session:
-        active_dag_query = (
+        active_alert_query = (
             session.query(
-                DelayAlertMetaData.dag_id
+                DelayAlertMetadata.dag_id,
+                DelayAlertMetadata.task_id,
             )
-            .join(DagModel, DelayAlertMetaData.dag_id == DagModel.dag_id)
+            .join(
+                DagModel,
+                DelayAlertMetadata.dag_id == DagModel.dag_id
+            )
             .filter(
-                DelayAlertMetaData.task_id.is_(None),
                 DagModel.is_active == True,
                 DagModel.is_paused == False,
             )
-            .group_by(DelayAlertMetaData.dag_id)
+            .group_by(
+                DelayAlertMetadata.dag_id,
+                DelayAlertMetadata.task_id,
+            )
             .subquery()
         )
 
-        execution_date_query = (
+        # Gather the current max execution dates
+        dag_max_execution_date = (
             session.query(
                 DagRun.dag_id,
-                DagRun.execution_date,
-                DagRun.state,
+                func.max(DagRun.execution_date).label("execution_date"),
             )
-            .join(active_dag_query, active_dag_query.c.dag_id == DagRun.dag_id)
-            .filter(
-                DagRun.execution_date > min_date_to_filter,
-            )
-            .order_by(DagRun.execution_date.desc())
-            .all()
-        )
-
-        execution_dates = defaultdict(list)
-        max_execution_dates = {}
-        for r in execution_date_query:
-            key = r.dag_id
-            execution_dates[key].append(r.execution_date)
-            if r.state == "success" and key not in max_execution_dates:
-                max_execution_dates[r.dag_id] = r.execution_date
-
-        runs = (
-            session.query(
-                DelayAlertMetaData.affected_pipeline,
-                DelayAlertMetaData.alert_external_classification,
-                DelayAlertMetaData.alert_report_classification,
-                DelayAlertMetaData.alert_target,
-                DelayAlertMetaData.cadence,
-                DelayAlertMetaData.dag_id,
-                DelayAlertMetaData.group_business_line,
-                DelayAlertMetaData.group_pagerduty,
-                DelayAlertMetaData.inhibit_rule,
-                DelayAlertMetaData.link,
-                DelayAlertMetaData.severity,
-                DelayAlertMetaData.sla_interval,
-                DelayAlertMetaData.sla_time,
-                LatestSuccessfulRun.execution_date.label("latest_successful_run"),
-            )
-            .join(active_dag_query, DelayAlertMetaData.dag_id == active_dag_query.c.dag_id)
             .join(
-                LatestSuccessfulRun,
-                and_(
-                    DelayAlertMetaData.dag_id == LatestSuccessfulRun.dag_id,
-                    LatestSuccessfulRun.task_id.is_(None),
-                ),
-                isouter=True
+                active_alert_query,
+                (DagRun.dag_id == active_alert_query.c.dag_id)
+                & (active_alert_query.c.task_id.is_(None)),
             )
             .filter(
-                DelayAlertMetaData.task_id.is_(None),
+                DagRun.state == State.SUCCESS,
+                DagRun.end_date.isnot(None),
             )
-            .all()
+            .group_by(DagRun.dag_id)
         )
 
-        metrics = []
-        insert_dict = {}
-        update_dict = {}
-        for run in runs:
-            key = run.dag_id
-
-            max_execution_date = max_execution_dates.get(
-                key,
-                datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
-            )
-            if run.latest_successful_run is None:
-                insert_dict[(run.dag_id, None)] = max_execution_date
-            elif max_execution_date > run.latest_successful_run:
-                update_dict[(run.dag_id, None)] = max_execution_date
-            else:
-                max_execution_date = run.latest_successful_run
-
-            metrics.append({
-                "affected_pipeline": run.affected_pipeline or MISSING,
-                "alert_external_classification": run.alert_external_classification
-                or MISSING,
-                "alert_report_classification": run.alert_report_classification
-                or MISSING,
-                "alert_target": run.alert_target or MISSING,
-                "dag_id": run.dag_id,
-                "group_business_line": run.group_business_line or MISSING,
-                "group_pagerduty": run.group_pagerduty or MISSING,
-                "inhibit_rule": run.inhibit_rule or MISSING,
-                "link": run.link or MISSING,
-                "severity": run.severity or MISSING,
-                "sla_miss": sla_check(
-                    run.sla_interval,
-                    run.sla_time,
-                    max_execution_date,
-                    run.cadence,
-                    execution_dates[key],
-                ),
-            })
-
-        insert_latest_successful_runs(session, insert_dict)
-        update_latest_successful_runs(session, update_dict)
-
-        return metrics
-
-
-def get_sla_miss_tasks():
-    min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
-    with session_scope(Session) as session:
-        active_task_query = (
-            session.query(
-                DelayAlertMetaData.dag_id,
-                DelayAlertMetaData.task_id,
-            )
-            .join(DagModel, DelayAlertMetaData.dag_id == DagModel.dag_id)
-            .filter(
-                DelayAlertMetaData.task_id.isnot(None),
-                DagModel.is_active == True,
-                DagModel.is_paused == False,
-            )
-            .group_by(DelayAlertMetaData.dag_id, DelayAlertMetaData.task_id)
-            .subquery()
-        )
-
-        execution_date_query = (
+        task_max_execution_date = (
             session.query(
                 TaskInstance.dag_id,
-                TaskInstance.execution_date,
-                TaskInstance.state,
                 TaskInstance.task_id,
+                func.max(TaskInstance.execution_date).label("execution_date"),
             )
             .join(
-                active_task_query,
-                and_(
-                    active_task_query.c.dag_id == TaskInstance.dag_id,
-                    active_task_query.c.task_id == TaskInstance.task_id,
-                ),
+                active_alert_query,
+                (TaskInstance.dag_id == active_alert_query.c.dag_id)
+                & (TaskInstance.task_id == active_alert_query.c.task_id),
             )
             .filter(
-                TaskInstance.execution_date > min_date_to_filter,
+                TaskInstance.state == State.SUCCESS,
+                TaskInstance.end_date.isnot(None),
             )
-            .order_by(TaskInstance.execution_date.desc())
-            .all()
+            .group_by(
+                TaskInstance.dag_id,
+                TaskInstance.task_id,
+            )
+            .union(
+                dag_max_execution_date
+            )
         )
 
-        execution_dates = defaultdict(list)
         max_execution_dates = {}
-        for r in execution_date_query:
-            key = (r.dag_id, r.task_id)
-            execution_dates[key].append(r.execution_date)
-            if r.state == "success" and key not in max_execution_dates:
-                max_execution_dates[key] = r.execution_date
+        for r in dag_max_execution_date:
+            max_execution_dates[(r.dag_id, r.task_id)] = r.execution_date
 
-        runs = (
+        # Getting all alerts with auxiliary data
+        alert_query = (
             session.query(
-                DelayAlertMetaData.affected_pipeline,
-                DelayAlertMetaData.alert_external_classification,
-                DelayAlertMetaData.alert_report_classification,
-                DelayAlertMetaData.alert_target,
-                DelayAlertMetaData.cadence,
-                DelayAlertMetaData.dag_id,
-                DelayAlertMetaData.group_business_line,
-                DelayAlertMetaData.group_pagerduty,
-                DelayAlertMetaData.inhibit_rule,
-                DelayAlertMetaData.link,
-                DelayAlertMetaData.severity,
-                DelayAlertMetaData.sla_interval,
-                DelayAlertMetaData.sla_time,
-                DelayAlertMetaData.task_id,
-                LatestSuccessfulRun.execution_date.label("latest_successful_run"),
+                DelayAlertMetadata.dag_id,
+                DelayAlertMetadata.task_id,
+                DelayAlertMetadata.affected_pipeline, DelayAlertMetadata.alert_target,
+                DelayAlertMetadata.alert_name,
+                DelayAlertMetadata.cadence,
+                DelayAlertMetadata.group_title,
+                DelayAlertMetadata.inhibit_rule,
+                DelayAlertMetadata.link,
+                DelayAlertMetadata.sla_interval,
+                DelayAlertMetadata.sla_time,
+                DelayAlertAuxiliaryInfo.latest_successful_run,
+                DelayAlertAuxiliaryInfo.latest_sla_miss_state,
             )
             .join(
-                active_task_query,
+                active_alert_query,
                 and_(
-                    DelayAlertMetaData.dag_id == active_task_query.c.dag_id,
-                    DelayAlertMetaData.task_id == active_task_query.c.task_id,
-                )
+                    DelayAlertMetadata.dag_id == active_alert_query.c.dag_id,
+                    func.coalesce( DelayAlertMetadata.task_id, "n/a")
+                    == func.coalesce(active_alert_query.c.task_id, "n/a")
+                ),
             )
             .join(
-                LatestSuccessfulRun,
+                DelayAlertAuxiliaryInfo,
                 and_(
-                    DelayAlertMetaData.dag_id == LatestSuccessfulRun.dag_id,
-                    DelayAlertMetaData.task_id == LatestSuccessfulRun.task_id,
+                    DelayAlertMetadata.dag_id == DelayAlertAuxiliaryInfo.dag_id,
+                    func.coalesce(DelayAlertMetadata.task_id, "n/a")
+                    == func.coalesce(DelayAlertAuxiliaryInfo.task_id, "n/a")
                 ),
                 isouter=True
             )
-            .filter(
-                DelayAlertMetaData.task_id.isnot(None),
-            )
-            .all()
         )
 
-        metrics = []
-        insert_dict = {}
-        update_dict = {}
-        for run in runs:
-            key = (run.dag_id, run.task_id)
+        processed = set()
+        epoch = pytz.timezone(TIMEZONE).localize(datetime.datetime.utcfromtimestamp(0))
+        for alert in alert_query:
+            key = (alert.dag_id, alert.task_id)
+            insert = update = False
 
-            max_execution_date = max_execution_dates.get(
-                key,
-                datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
-            )
-            if max_execution_date is None:
-                continue
-            elif run.latest_successful_run is None and max_execution_date:
-                insert_dict[(run.dag_id, run.task_id)] = max_execution_date
-            elif max_execution_date > run.latest_successful_run:
-                update_dict[(run.dag_id, run.task_id)] = max_execution_date
+            max_execution_date = max_execution_dates.get(key, epoch)
+            if alert.latest_successful_run is None:
+                insert = True
+            elif max_execution_date > alert.latest_successful_run:
+                update = True
             else:
-                max_execution_date = run.latest_successful_run
+                max_execution_date = alert.latest_successful_run
 
-            metrics.append({
-                "affected_pipeline": run.affected_pipeline or MISSING,
-                "alert_external_classification": run.alert_external_classification
-                or MISSING,
-                "alert_report_classification": run.alert_report_classification
-                or MISSING,
-                "alert_target": run.alert_target or MISSING,
-                "dag_id": run.dag_id,
-                "group_business_line": run.group_business_line or MISSING,
-                "group_pagerduty": run.group_pagerduty or MISSING,
-                "inhibit_rule": run.inhibit_rule or MISSING,
-                "link": run.link or MISSING,
-                "severity": run.severity or MISSING,
-                "task_id": run.task_id or MISSING,
-                "sla_miss": sla_check(
-                    run.sla_interval,
-                    run.sla_time,
-                    max_execution_date,
-                    run.cadence,
-                    execution_dates[key],
-                )
-            })
+            sla_miss = sla_check(
+                alert.sla_interval,
+                alert.sla_time,
+                max_execution_date,
+                alert.cadence,
+                alert.latest_sla_miss_state,
+            )
 
-        insert_latest_successful_runs(session, insert_dict)
-        update_latest_successful_runs(session, update_dict)
+            if key not in processed and (insert or update or sla_miss != alert.latest_sla_miss_state):
+                processed.add(key)
+                values = {
+                    "max_execution_date": max_execution_date,
+                    "sla_miss": sla_miss,
+                }
+                upsert_auxiliary_info(session, key, values, insert)
 
-        return metrics
+            yield {
+                "dag_id": alert.dag_id,
+                "task_id": alert.task_id or MISSING,
+                "affected_pipeline": alert.affected_pipeline or MISSING,
+                "alert_name": alert.alert_name or alert.dag_id,
+                "alert_target": alert.alert_target or MISSING,
+                "group_title": alert.group_title or alert.alert_name,
+                "inhibit_rule": alert.inhibit_rule or MISSING,
+                "link": alert.link or DEFAULT_LINK,
+                "sla_interval": alert.sla_interval,
+                "sla_miss": sla_miss,
+                "sla_time": alert.sla_time or MISSING,
+            }
+
+        session.flush()
+        session.commit()
 
 
 class MetricsCollector(object):
@@ -695,120 +397,6 @@ class MetricsCollector(object):
 
     def collect(self):
         """Collect metrics."""
-        # Task metrics
-        task_info = get_task_state_info()
-        t_state = GaugeMetricFamily(
-            "airflow_task_status",
-            "Shows the number of task instances with particular status",
-            labels=[
-                "dag_id",
-                "task_id",
-                "owner",
-                "status",
-                "cadence",
-                "severity",
-                "alert_target",
-                "alert_external_classification",
-                "alert_report_classification",
-                "sla_time",
-                "network",
-                "business",
-            ],
-        )
-        for task in task_info:
-            t_state.add_metric(
-                [
-                    task.dag_id,
-                    task.task_id,
-                    task.owners,
-                    task.state or MISSING,
-                    task.cadence or MISSING,
-                    task.severity or MISSING,
-                    task.alert_target or MISSING,
-                    task.alert_external_classification or MISSING,
-                    task.alert_report_classification or MISSING,
-                    task.sla_time or MISSING,
-                    "network",
-                    "business",
-                ],
-                task.value,
-            )
-        yield t_state
-
-        task_duration = GaugeMetricFamily(
-            "airflow_task_duration",
-            "Duration of successful tasks in seconds",
-            labels=["task_id", "dag_id", "execution_date"],
-        )
-        for task in get_task_duration_info():
-            task_duration_value = (task.end_date - task.start_date).total_seconds()
-            task_duration.add_metric(
-                [
-                    task.task_id,
-                    task.dag_id,
-                    task.execution_date.strftime("%Y-%m-%dT%H:%M%S"),
-                ],
-                task_duration_value,
-            )
-        yield task_duration
-
-        task_failure_count = GaugeMetricFamily(
-            "airflow_task_fail_count",
-            "Count of failed tasks",
-            labels=["dag_id", "task_id"],
-        )
-        for task in get_task_failure_counts():
-            task_failure_count.add_metric([task.dag_id, task.task_id], task.count)
-        yield task_failure_count
-
-        # Dag Metrics
-        dag_info = get_dag_state_info()
-        d_state = GaugeMetricFamily(
-            "airflow_dag_status",
-            "Shows the number of dag starts with this status",
-            labels=[
-                "dag_id",
-                "owner",
-                "status",
-                "cadence",
-                "severity",
-                "alert_target",
-                "alert_external_classification",
-                "alert_report_classification",
-                "sla_time",
-                "network",
-                "business",
-            ],
-        )
-        for dag in dag_info:
-            d_state.add_metric(
-                [
-                    dag.dag_id,
-                    dag.owners,
-                    dag.state,
-                    dag.cadence or MISSING,
-                    dag.severity or MISSING,
-                    dag.alert_target or MISSING,
-                    dag.alert_external_classification or MISSING,
-                    dag.alert_report_classification or MISSING,
-                    dag.sla_time or MISSING,
-                    "network",
-                    "business",
-                ],
-                dag.count,
-            )
-        yield d_state
-
-        dag_duration = GaugeMetricFamily(
-            "airflow_dag_run_duration",
-            "Duration of successful dag_runs in seconds",
-            labels=["dag_id"],
-        )
-        for dag in get_dag_duration_info():
-            dag_duration_value = (dag.end_date - dag.start_date).total_seconds()
-            dag_duration.add_metric([dag.dag_id], dag_duration_value)
-        yield dag_duration
-
         # Scheduler Metrics
         dag_scheduler_delay = GaugeMetricFamily(
             "airflow_dag_scheduler_delay",
@@ -864,78 +452,41 @@ class MetricsCollector(object):
         num_queued_tasks_metric.add_metric([], num_queued_tasks)
         yield num_queued_tasks_metric
 
-        sla_miss_dags_metric = GaugeMetricFamily(
-            "airflow_dags_sla_miss",
+        sla_miss_metric = GaugeMetricFamily(
+            "airflow_sla_miss",
             "Airflow DAGS missing the sla",
             labels=[
-                "affected_pipeline",
-                "alert_external_classification",
-                "alert_report_classification",
-                "alert_target",
                 "dag_id",
-                "group_business_line",
-                "group_pagerduty",
+                "task_id",
+                "affected_pipeline",
+                "alert_name",
+                "alert_target",
+                "group_title",
                 "inhibit_rule",
                 "link",
-                "severity",
+                "sla_interval",
+                "sla_time",
             ],
         )
 
-        for dag in get_sla_miss_dags():
+        for alert in get_sla_miss():
             sla_miss_dags_metric.add_metric(
                 [
-                    dag["affected_pipeline"],
-                    dag["alert_external_classification"],
-                    dag["alert_report_classification"],
-                    dag["alert_target"],
-                    dag["dag_id"],
-                    dag["group_business_line"],
-                    dag["group_pagerduty"],
-                    dag["inhibit_rule"],
-                    dag["link"],
-                    dag["severity"],
+                    alert["dag_id"],
+                    alert["task_id"],
+                    alert["affected_pipeline"],
+                    alert["alert_name"],
+                    alert["alert_target"],
+                    alert["group_title"],
+                    alert["inhibit_rule"],
+                    alert["link"],
+                    alert["sla_interval"],
+                    alert["sla_time"],
                 ],
-                dag["sla_miss"],
+                alert["sla_miss"],
             )
 
-        yield sla_miss_dags_metric
-
-        sla_miss_tasks_metric = GaugeMetricFamily(
-            "airflow_tasks_sla_miss",
-            "Airflow tasks missing the sla",
-            labels=[
-                "affected_pipeline",
-                "alert_external_classification",
-                "alert_report_classification",
-                "alert_target",
-                "dag_id",
-                "group_business_line",
-                "group_pagerduty",
-                "inhibit_rule",
-                "link",
-                "severity",
-                "task_id",
-            ],
-        )
-
-        for tasks in get_sla_miss_tasks():
-            sla_miss_tasks_metric.add_metric(
-                [
-                    tasks["affected_pipeline"],
-                    tasks["alert_external_classification"],
-                    tasks["alert_report_classification"],
-                    tasks["alert_target"],
-                    tasks["dag_id"],
-                    tasks["group_business_line"],
-                    tasks["group_pagerduty"],
-                    tasks["inhibit_rule"],
-                    tasks["link"],
-                    tasks["severity"],
-                    tasks["task_id"],
-                ],
-                tasks["sla_miss"],
-            )
-        yield sla_miss_tasks_metric
+        yield sla_miss_metric
 
 
 REGISTRY.register(MetricsCollector())

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -44,28 +44,27 @@ def session_scope(session):
         session.close()
 
 
-session = session_scope(Session)
+with session_scope(Session) as session:
+    Base = declarative_base(session.get_bind())
 
-Base = declarative_base(session.get_bind())
-
-class DelayAlertMetadata(Base):
-    __tablename__ = "delay_alert_metadata"
-    __table_args__ = {
-        "schema": "ddns",
-        "autoload": True
-    }
-    dag_id = Column(String, primary_key=True)
+    class DelayAlertMetadata(Base):
+        __tablename__ = "delay_alert_metadata"
+        __table_args__ = {
+            "schema": "ddns",
+            "autoload": True
+        }
+        dag_id = Column(String, primary_key=True)
 
 
-class DelayAlertAuxiliaryInfo(Base):
-    __tablename__ = "delay_alert_auxiliary_info"
-    __table_args__ = {
-        "schema": "ddns",
-        "autoload": True
-    }
-    dag_id = Column(String, primary_key=True)
-    task_id = Column(String, primary_key=True, nullable=True)
-    latest_successful_run = Column(UTCDateTime)
+    class DelayAlertAuxiliaryInfo(Base):
+        __tablename__ = "delay_alert_auxiliary_info"
+        __table_args__ = {
+            "schema": "ddns",
+            "autoload": True
+        }
+        dag_id = Column(String, primary_key=True)
+        task_id = Column(String, primary_key=True, nullable=True)
+        latest_successful_run = Column(UTCDateTime)
 
 ######################
 # DAG Related Metrics
@@ -75,102 +74,93 @@ class DelayAlertAuxiliaryInfo(Base):
 def get_dag_state_info():
     """Number of DAG Runs with particular state."""
     min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
-    dag_status_query = (
-        session.query(
-            DagRun.dag_id, DagRun.state, func.count(DagRun.state).label("count")
+    with session_scope(Session) as session:
+        dag_status_query = (
+            session.query(
+                DagRun.dag_id, DagRun.state, func.count(DagRun.state).label("count")
+            )
+            .filter(
+                DagRun.execution_date > min_date_to_filter,
+                DagRun.external_trigger == False,
+                DagRun.state.isnot(None),
+            )
+            .group_by(DagRun.dag_id, DagRun.state)
+            .subquery()
         )
-        .filter(
-            DagRun.execution_date > min_date_to_filter,
-            DagRun.external_trigger == False,
-            DagRun.state.isnot(None),
-        )  # noqa
-        .group_by(DagRun.dag_id, DagRun.state)
-        .subquery()
-    )
-    return (
-        session.query(
-            dag_status_query.c.dag_id,
-            dag_status_query.c.state,
-            dag_status_query.c.count,
-            DagModel.owners,
-            DelayAlertMetaData.cadence,
-            DelayAlertMetaData.severity,
-            DelayAlertMetaData.alert_target,
-            DelayAlertMetaData.alert_external_classification,
-            DelayAlertMetaData.alert_report_classification,
-            DelayAlertMetaData.sla_time,
+        return (
+            session.query(
+                dag_status_query.c.dag_id,
+                dag_status_query.c.state,
+                dag_status_query.c.count,
+                DagModel.owners,
+            )
+            .join(DagModel, DagModel.dag_id == dag_status_query.c.dag_id)
+            .filter(DagModel.is_active == True, DagModel.is_paused == False)
+            .all()
         )
-        .join(DagModel, DagModel.dag_id == dag_status_query.c.dag_id)
-        .filter(DagModel.is_active == True, DagModel.is_paused == False)  # noqa
-        .outerjoin(
-            DelayAlertMetaData,
-            DelayAlertMetaData.dag_id == dag_status_query.c.dag_id,
-        )
-        .filter(DelayAlertMetaData.task_id.is_(None))
-        .all()
-    )
 
 
 def get_dag_duration_info():
     """Duration of successful DAG Runs."""
     min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
-    max_execution_dt_query = (
-        session.query(
-            DagRun.dag_id, func.max(DagRun.execution_date).label("max_execution_dt")
+    with session_scope(Session) as session:
+        max_execution_dt_query = (
+            session.query(
+                DagRun.dag_id, func.max(DagRun.execution_date).label("max_execution_dt")
+            )
+            .join(DagModel, DagModel.dag_id == DagRun.dag_id)
+            .filter(
+                DagModel.is_active == True,  # noqa
+                DagModel.is_paused == False,
+                DagRun.state == State.SUCCESS,
+                DagRun.end_date.isnot(None),
+                DagRun.execution_date > min_date_to_filter,
+            )
+            .group_by(DagRun.dag_id)
+            .subquery()
         )
-        .join(DagModel, DagModel.dag_id == DagRun.dag_id)
-        .filter(
-            DagModel.is_active == True,  # noqa
-            DagModel.is_paused == False,
-            DagRun.state == State.SUCCESS,
-            DagRun.end_date.isnot(None),
-            DagRun.execution_date > min_date_to_filter,
-        )
-        .group_by(DagRun.dag_id)
-        .subquery()
-    )
 
-    dag_start_dt_query = (
-        session.query(
-            max_execution_dt_query.c.dag_id,
-            max_execution_dt_query.c.max_execution_dt.label("execution_date"),
-            func.min(TaskInstance.start_date).label("start_date"),
-        )
-        .join(
-            TaskInstance,
-            and_(
-                TaskInstance.dag_id == max_execution_dt_query.c.dag_id,
-                (
-                    TaskInstance.execution_date
-                    == max_execution_dt_query.c.max_execution_dt  # noqa
+        dag_start_dt_query = (
+            session.query(
+                max_execution_dt_query.c.dag_id,
+                max_execution_dt_query.c.max_execution_dt.label("execution_date"),
+                func.min(TaskInstance.start_date).label("start_date"),
+            )
+            .join(
+                TaskInstance,
+                and_(
+                    TaskInstance.dag_id == max_execution_dt_query.c.dag_id,
+                    (
+                        TaskInstance.execution_date
+                        == max_execution_dt_query.c.max_execution_dt  # noqa
+                    ),
                 ),
-            ),
+            )
+            .filter(
+                TaskInstance.start_date.isnot(None), TaskInstance.end_date.isnot(None)
+            )
+            .group_by(
+                max_execution_dt_query.c.dag_id,
+                max_execution_dt_query.c.max_execution_dt,
+            )
+            .subquery()
         )
-        .filter(
-            TaskInstance.start_date.isnot(None), TaskInstance.end_date.isnot(None)
-        )
-        .group_by(
-            max_execution_dt_query.c.dag_id,
-            max_execution_dt_query.c.max_execution_dt,
-        )
-        .subquery()
-    )
 
-    return (
-        session.query(
-            dag_start_dt_query.c.dag_id,
-            dag_start_dt_query.c.start_date,
-            DagRun.end_date,
+        return (
+            session.query(
+                dag_start_dt_query.c.dag_id,
+                dag_start_dt_query.c.start_date,
+                DagRun.end_date,
+            )
+            .join(
+                DagRun,
+                and_(
+                    DagRun.dag_id == dag_start_dt_query.c.dag_id,
+                    DagRun.execution_date == dag_start_dt_query.c.execution_date,
+                ),
+            )
+            .all()
         )
-        .join(
-            DagRun,
-            and_(
-                DagRun.dag_id == dag_start_dt_query.c.dag_id,
-                DagRun.execution_date == dag_start_dt_query.c.execution_date,
-            ),
-        )
-        .all()
-    )
 
 
 ######################
@@ -181,79 +171,70 @@ def get_dag_duration_info():
 def get_task_state_info():
     """Number of task instances with particular state."""
     min_date_to_filter = pendulum.now(TIMEZONE).subtract(days=RETENTION_TIME)
-    task_status_query = (
-        session.query(
-            TaskInstance.dag_id,
-            TaskInstance.task_id,
-            TaskInstance.state,
-            func.count(TaskInstance.dag_id).label("value"),
+    with session_scope(Session) as session:
+        task_status_query = (
+            session.query(
+                TaskInstance.dag_id,
+                TaskInstance.task_id,
+                TaskInstance.state,
+                func.count(TaskInstance.dag_id).label("value"),
+            )
+            .group_by(TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.state)
+            .filter(TaskInstance.execution_date > min_date_to_filter)
+            .subquery()
         )
-        .group_by(TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.state)
-        .filter(TaskInstance.execution_date > min_date_to_filter)
-        .subquery()
-    )
-    return (
-        session.query(
-            task_status_query.c.dag_id,
-            task_status_query.c.task_id,
-            task_status_query.c.state,
-            task_status_query.c.value,
-            DagModel.owners,
-            DelayAlertMetaData.cadence,
-            DelayAlertMetaData.severity,
-            DelayAlertMetaData.alert_target,
-            DelayAlertMetaData.alert_external_classification,
-            DelayAlertMetaData.alert_report_classification,
-            DelayAlertMetaData.sla_time,
+        return (
+            session.query(
+                task_status_query.c.dag_id,
+                task_status_query.c.task_id,
+                task_status_query.c.state,
+                task_status_query.c.value,
+                DagModel.owners,
+            )
+            .join(DagModel, DagModel.dag_id == task_status_query.c.dag_id)
+            .filter(DagModel.is_active == True, DagModel.is_paused == False)  # noqa
+            .all()
         )
-        .join(DagModel, DagModel.dag_id == task_status_query.c.dag_id)
-        .filter(DagModel.is_active == True, DagModel.is_paused == False)  # noqa
-        .outerjoin(
-            DelayAlertMetaData,
-            (DelayAlertMetaData.dag_id == task_status_query.c.dag_id)
-            & (DelayAlertMetaData.task_id == task_status_query.c.task_id),  # noqa
-        )
-        .filter(DelayAlertMetaData.task_id.isnot(None))
-        .all()
-    )
 
 
 def get_task_failure_counts():
     """Compute Task Failure Counts."""
-    return (
-        session.query(
-            TaskFail.dag_id,
-            TaskFail.task_id,
-            func.count(TaskFail.dag_id).label("count"),
+    with session_scope(Session) as session:
+        return (
+            session.query(
+                TaskFail.dag_id,
+                TaskFail.task_id,
+                func.count(TaskFail.dag_id).label("count"),
+            )
+            .join(DagModel, DagModel.dag_id == TaskFail.dag_id)
+            .filter(DagModel.is_active == True, DagModel.is_paused == False)  # noqa
+            .group_by(TaskFail.dag_id, TaskFail.task_id)
         )
-        .join(DagModel, DagModel.dag_id == TaskFail.dag_id)
-        .filter(DagModel.is_active == True, DagModel.is_paused == False)  # noqa
-        .group_by(TaskFail.dag_id, TaskFail.task_id)
-    )
 
 
 def get_xcom_params(task_id):
     """XCom parameters for matching task_id's for the latest run of a DAG."""
-    max_execution_dt_query = (
-        session.query(
-            DagRun.dag_id, func.max(DagRun.execution_date).label("max_execution_dt")
+    with session_scope(Session) as session:
+        max_execution_dt_query = (
+            session.query(
+                DagRun.dag_id, func.max(DagRun.execution_date).label("max_execution_dt")
+            )
+            .filter(TaskInstance.state.isnot(None))
+            .group_by(DagRun.dag_id)
+            .subquery()
         )
-        .filter(TaskInstance.state.isnot(None))
-        .group_by(DagRun.dag_id)
-        .subquery()
-    )
 
-    query = session.query(XCom.dag_id, XCom.task_id, XCom.value).join(
-        max_execution_dt_query,
-        and_(
-            (XCom.dag_id == max_execution_dt_query.c.dag_id),
-            (XCom.execution_date == max_execution_dt_query.c.max_execution_dt),
-        ),
-    )
-    if task_id == "all":
-        return query.all()
-    else:
-        return query.filter(XCom.task_id == task_id).all()
+        query = session.query(XCom.dag_id, XCom.task_id, XCom.value).join(
+            max_execution_dt_query,
+            and_(
+                (XCom.dag_id == max_execution_dt_query.c.dag_id),
+                (XCom.execution_date == max_execution_dt_query.c.max_execution_dt),
+            ),
+        )
+        if task_id == "all":
+            return query.all()
+        else:
+            return query.filter(XCom.task_id == task_id).all()
 
 
 def extract_xcom_parameter(value):
@@ -280,6 +261,51 @@ def extract_xcom_parameter(value):
             return {}
 
 
+def get_task_duration_info():
+    """Duration of successful tasks in seconds."""
+    with session_scope(Session) as session:
+        max_execution_dt_query = (
+            session.query(
+                DagRun.dag_id, func.max(DagRun.execution_date).label("max_execution_dt")
+            )
+            .join(DagModel, DagModel.dag_id == DagRun.dag_id)
+            .filter(
+                DagModel.is_active == True,  # noqa
+                DagModel.is_paused == False,
+                DagRun.state == State.SUCCESS,
+                DagRun.end_date.isnot(None),
+            )
+            .group_by(DagRun.dag_id)
+            .subquery()
+        )
+
+        return (
+            session.query(
+                TaskInstance.dag_id,
+                TaskInstance.task_id,
+                TaskInstance.start_date,
+                TaskInstance.end_date,
+                TaskInstance.execution_date,
+            )
+            .join(
+                max_execution_dt_query,
+                and_(
+                    (TaskInstance.dag_id == max_execution_dt_query.c.dag_id),
+                    (
+                        TaskInstance.execution_date
+                        == max_execution_dt_query.c.max_execution_dt  # noqa
+                    ),
+                ),
+            )
+            .filter(
+                TaskInstance.state == State.SUCCESS,
+                TaskInstance.start_date.isnot(None),
+                TaskInstance.end_date.isnot(None),
+            )
+            .all()
+        )
+
+
 ######################
 # Scheduler Related Metrics
 ######################
@@ -287,53 +313,56 @@ def extract_xcom_parameter(value):
 
 def get_dag_scheduler_delay():
     """Compute DAG scheduling delay."""
-    return (
-        session.query(DagRun.dag_id, DagRun.execution_date, DagRun.start_date)
-        .filter(DagRun.dag_id == CANARY_DAG)
-        .order_by(DagRun.execution_date.desc())
-        .limit(1)
-        .all()
-    )
+    with session_scope(Session) as session:
+        return (
+            session.query(DagRun.dag_id, DagRun.execution_date, DagRun.start_date)
+            .filter(DagRun.dag_id == CANARY_DAG)
+            .order_by(DagRun.execution_date.desc())
+            .limit(1)
+            .all()
+        )
 
 
 def get_task_scheduler_delay():
     """Compute Task scheduling delay."""
-    task_status_query = (
-        session.query(
-            TaskInstance.queue, func.max(TaskInstance.start_date).label("max_start")
+    with session_scope(Session) as session:
+        task_status_query = (
+            session.query(
+                TaskInstance.queue, func.max(TaskInstance.start_date).label("max_start")
+            )
+            .filter(
+                TaskInstance.dag_id == CANARY_DAG, TaskInstance.queued_dttm.isnot(None)
+            )
+            .group_by(TaskInstance.queue)
+            .subquery()
         )
-        .filter(
-            TaskInstance.dag_id == CANARY_DAG, TaskInstance.queued_dttm.isnot(None)
+        return (
+            session.query(
+                task_status_query.c.queue,
+                TaskInstance.execution_date,
+                TaskInstance.queued_dttm,
+                task_status_query.c.max_start.label("start_date"),
+            )
+            .join(
+                TaskInstance,
+                and_(
+                    TaskInstance.queue == task_status_query.c.queue,
+                    TaskInstance.start_date == task_status_query.c.max_start,
+                ),
+            )
+            .filter(TaskInstance.dag_id == CANARY_DAG)  # Redundant, for performance.
+            .all()
         )
-        .group_by(TaskInstance.queue)
-        .subquery()
-    )
-    return (
-        session.query(
-            task_status_query.c.queue,
-            TaskInstance.execution_date,
-            TaskInstance.queued_dttm,
-            task_status_query.c.max_start.label("start_date"),
-        )
-        .join(
-            TaskInstance,
-            and_(
-                TaskInstance.queue == task_status_query.c.queue,
-                TaskInstance.start_date == task_status_query.c.max_start,
-            ),
-        )
-        .filter(TaskInstance.dag_id == CANARY_DAG)  # Redundant, for performance.
-        .all()
-    )
 
 
 def get_num_queued_tasks():
     """Number of queued tasks currently."""
-    return (
-        session.query(TaskInstance)
-        .filter(TaskInstance.state == State.QUEUED)
-        .count()
-    )
+    with session_scope(Session) as session:
+        return (
+            session.query(TaskInstance)
+            .filter(TaskInstance.state == State.QUEUED)
+            .count()
+        )
 
 def sla_check(sla_interval, sla_time, max_execution_date, cadence, latest_sla_miss_state):
     utc_datetime = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
@@ -364,7 +393,7 @@ def sla_check(sla_interval, sla_time, max_execution_date, cadence, latest_sla_mi
     return False
 
 
-def upsert_auxiliary_info(upsert_dict):
+def upsert_auxiliary_info(session, upsert_dict):
     for k, v in upsert_dict.items():
         dag_id, task_id = k
         value = v["value"]
@@ -392,185 +421,187 @@ def upsert_auxiliary_info(upsert_dict):
 
 
 def get_sla_miss():
-    active_alert_query = (
-        session.query(
-            DelayAlertMetadata.dag_id,
-            DelayAlertMetadata.task_id,
-        )
-        .join(
-            DagModel,
-            DelayAlertMetadata.dag_id == DagModel.dag_id
-        )
-        .filter(
-            DagModel.is_active == True,
-            DagModel.is_paused == False,
-        )
-        .group_by(
-            DelayAlertMetadata.dag_id,
-            DelayAlertMetadata.task_id,
-        )
-        .subquery()
-    )
-
-    # Gather the current max execution dates
-    dag_max_execution_date = (
-        session.query(
-            DagRun.dag_id,
-            null().label("task_id"),
-            func.max(DagRun.execution_date).label("execution_date"),
-        )
-        .join(
-            active_alert_query,
-            (DagRun.dag_id == active_alert_query.c.dag_id)
-            & (active_alert_query.c.task_id.is_(None)),
-        )
-        .filter(
-            DagRun.state == State.SUCCESS,
-            DagRun.end_date.isnot(None),
-        )
-        .group_by(DagRun.dag_id)
-    )
-
-    task_max_execution_date = (
-        session.query(
-            TaskInstance.dag_id,
-            TaskInstance.task_id,
-            func.max(TaskInstance.execution_date).label("execution_date"),
-        )
-        .join(
-            active_alert_query,
-            (TaskInstance.dag_id == active_alert_query.c.dag_id)
-            & (TaskInstance.task_id == active_alert_query.c.task_id),
-        )
-        .filter(
-            TaskInstance.state == State.SUCCESS,
-            TaskInstance.end_date.isnot(None),
-        )
-        .group_by(
-            TaskInstance.dag_id,
-            TaskInstance.task_id,
-        )
-        .union(
-            dag_max_execution_date
-        )
-    )
-
-    max_execution_dates = {}
-    for r in dag_max_execution_date:
-        max_execution_dates[(r.dag_id, r.task_id)] = r.execution_date
-
-    # Getting all alerts with auxiliary data
-    alert_query = (
-        session.query(
-            DelayAlertMetadata.dag_id,
-            DelayAlertMetadata.task_id,
-            DelayAlertMetadata.affected_pipeline, DelayAlertMetadata.alert_target,
-            DelayAlertMetadata.alert_name,
-            DelayAlertMetadata.cadence,
-            DelayAlertMetadata.group_title,
-            DelayAlertMetadata.inhibit_rule,
-            DelayAlertMetadata.link,
-            DelayAlertMetadata.sla_interval,
-            DelayAlertMetadata.sla_time,
-            DelayAlertAuxiliaryInfo.latest_successful_run,
-            DelayAlertAuxiliaryInfo.latest_sla_miss_state,
-        )
-        .join(
-            active_alert_query,
-            and_(
-                DelayAlertMetadata.dag_id == active_alert_query.c.dag_id,
-                func.coalesce( DelayAlertMetadata.task_id, "n/a")
-                == func.coalesce(active_alert_query.c.task_id, "n/a")
-            ),
-        )
-        .join(
-            DelayAlertAuxiliaryInfo,
-            and_(
-                DelayAlertMetadata.dag_id == DelayAlertAuxiliaryInfo.dag_id,
-                func.coalesce(DelayAlertMetadata.task_id, "n/a")
-                == func.coalesce(DelayAlertAuxiliaryInfo.task_id, "n/a")
-            ),
-            isouter=True
-        )
-    )
-
-    epoch = datetime.datetime.utcfromtimestamp(0).replace(tzinfo=datetime.timezone.utc)
-    upsert_dict = {}
-    for alert in alert_query:
-        key = (alert.dag_id, alert.task_id)
-        insert = update = False
-
-        max_execution_date = max_execution_dates.get(key, epoch)
-        if alert.latest_successful_run is None:
-            insert = True
-        elif max_execution_date > alert.latest_successful_run:
-            update = True
-        else:
-            max_execution_date = alert.latest_successful_run
-
-        sla_miss = sla_check(
-            alert.sla_interval,
-            alert.sla_time,
-            max_execution_date,
-            alert.cadence,
-            alert.latest_sla_miss_state,
+    with session_scope(Session) as session:
+        active_alert_query = (
+            session.query(
+                DelayAlertMetadata.dag_id,
+                DelayAlertMetadata.task_id,
+            )
+            .join(
+                DagModel,
+                DelayAlertMetadata.dag_id == DagModel.dag_id
+            )
+            .filter(
+                DagModel.is_active == True,
+                DagModel.is_paused == False,
+            )
+            .group_by(
+                DelayAlertMetadata.dag_id,
+                DelayAlertMetadata.task_id,
+            )
+            .subquery()
         )
 
-        if insert or update or sla_miss != alert.latest_sla_miss_state:
-            upsert_dict[key] = {
-                "value":  {
-                    "max_execution_date": max_execution_date,
-                    "sla_miss": sla_miss,
-                },
-                "insert": insert,
+        # Gather the current max execution dates
+        dag_max_execution_date = (
+            session.query(
+                DagRun.dag_id,
+                null().label("task_id"),
+                func.max(DagRun.execution_date).label("execution_date"),
+            )
+            .join(
+                active_alert_query,
+                (DagRun.dag_id == active_alert_query.c.dag_id)
+                & (active_alert_query.c.task_id.is_(None)),
+            )
+            .filter(
+                DagRun.state == State.SUCCESS,
+                DagRun.end_date.isnot(None),
+            )
+            .group_by(DagRun.dag_id)
+        )
+
+        task_max_execution_date = (
+            session.query(
+                TaskInstance.dag_id,
+                TaskInstance.task_id,
+                func.max(TaskInstance.execution_date).label("execution_date"),
+            )
+            .join(
+                active_alert_query,
+                (TaskInstance.dag_id == active_alert_query.c.dag_id)
+                & (TaskInstance.task_id == active_alert_query.c.task_id),
+            )
+            .filter(
+                TaskInstance.state == State.SUCCESS,
+                TaskInstance.end_date.isnot(None),
+            )
+            .group_by(
+                TaskInstance.dag_id,
+                TaskInstance.task_id,
+            )
+            .union(
+                dag_max_execution_date
+            )
+        )
+
+        max_execution_dates = {}
+        for r in dag_max_execution_date:
+            max_execution_dates[(r.dag_id, r.task_id)] = r.execution_date
+
+        # Getting all alerts with auxiliary data
+        alert_query = (
+            session.query(
+                DelayAlertMetadata.dag_id,
+                DelayAlertMetadata.task_id,
+                DelayAlertMetadata.affected_pipeline, DelayAlertMetadata.alert_target,
+                DelayAlertMetadata.alert_name,
+                DelayAlertMetadata.cadence,
+                DelayAlertMetadata.group_title,
+                DelayAlertMetadata.inhibit_rule,
+                DelayAlertMetadata.link,
+                DelayAlertMetadata.sla_interval,
+                DelayAlertMetadata.sla_time,
+                DelayAlertAuxiliaryInfo.latest_successful_run,
+                DelayAlertAuxiliaryInfo.latest_sla_miss_state,
+            )
+            .join(
+                active_alert_query,
+                and_(
+                    DelayAlertMetadata.dag_id == active_alert_query.c.dag_id,
+                    func.coalesce( DelayAlertMetadata.task_id, "n/a")
+                    == func.coalesce(active_alert_query.c.task_id, "n/a")
+                ),
+            )
+            .join(
+                DelayAlertAuxiliaryInfo,
+                and_(
+                    DelayAlertMetadata.dag_id == DelayAlertAuxiliaryInfo.dag_id,
+                    func.coalesce(DelayAlertMetadata.task_id, "n/a")
+                    == func.coalesce(DelayAlertAuxiliaryInfo.task_id, "n/a")
+                ),
+                isouter=True
+            )
+        )
+
+        epoch = datetime.datetime.utcfromtimestamp(0).replace(tzinfo=datetime.timezone.utc)
+        upsert_dict = {}
+        for alert in alert_query:
+            key = (alert.dag_id, alert.task_id)
+            insert = update = False
+
+            max_execution_date = max_execution_dates.get(key, epoch)
+            if alert.latest_successful_run is None:
+                insert = True
+            elif max_execution_date > alert.latest_successful_run:
+                update = True
+            else:
+                max_execution_date = alert.latest_successful_run
+
+            sla_miss = sla_check(
+                alert.sla_interval,
+                alert.sla_time,
+                max_execution_date,
+                alert.cadence,
+                alert.latest_sla_miss_state,
+            )
+
+            if insert or update or sla_miss != alert.latest_sla_miss_state:
+                upsert_dict[key] = {
+                    "value":  {
+                        "max_execution_date": max_execution_date,
+                        "sla_miss": sla_miss,
+                    },
+                    "insert": insert,
+                }
+
+            alert_name = alert.alert_name
+            if alert_name is None:
+                alert_name = alert.dag_id
+                if alert.task_id:
+                    alert_name += "." + alert.task_id
+
+            yield {
+                "dag_id": alert.dag_id,
+                "task_id": alert.task_id or MISSING,
+                "affected_pipeline": alert.affected_pipeline or MISSING,
+                "alert_name": alert_name,
+                "alert_target": alert.alert_target or MISSING,
+                "group_title": alert.group_title or alert.alert_name,
+                "inhibit_rule": alert.inhibit_rule or MISSING,
+                "link": alert.link or MISSING,
+                "sla_interval": alert.sla_interval,
+                "sla_miss": sla_miss,
+                "sla_time": alert.sla_time or MISSING,
             }
 
-        alert_name = alert.alert_name
-        if alert_name is None:
-            alert_name = alert.dag_id
-            if alert.task_id:
-                alert_name += "." + alert.task_id
-
-        yield {
-            "dag_id": alert.dag_id,
-            "task_id": alert.task_id or MISSING,
-            "affected_pipeline": alert.affected_pipeline or MISSING,
-            "alert_name": alert_name,
-            "alert_target": alert.alert_target or MISSING,
-            "group_title": alert.group_title or alert.alert_name,
-            "inhibit_rule": alert.inhibit_rule or MISSING,
-            "link": alert.link or MISSING,
-            "sla_interval": alert.sla_interval,
-            "sla_miss": sla_miss,
-            "sla_time": alert.sla_time or MISSING,
-        }
-
-    upsert_auxiliary_info(upsert_dict)
+        upsert_auxiliary_info(session, upsert_dict)
 
 
 def get_unmonitored_dag():
-    query = (
-        session.query(
-            DagModel.dag_id,
-            DelayAlertMetadata.dag_id.is_(None).label("unmonitored"),
+    with session_scope(Session) as session:
+        query = (
+            session.query(
+                DagModel.dag_id,
+                DelayAlertMetadata.dag_id.is_(None).label("unmonitored"),
+            )
+            .join(
+                DelayAlertMetadata,
+                DagModel.dag_id == DelayAlertMetadata.dag_id,
+                isouter=True,
+            )
+            .filter(
+                DagModel.is_active == True,
+                DagModel.is_paused == False,
+            )
+            .group_by(
+                DagModel.dag_id,
+                "unmonitored",
+            )
         )
-        .join(
-            DelayAlertMetadata,
-            DagModel.dag_id == DelayAlertMetadata.dag_id,
-            isouter=True,
-        )
-        .filter(
-            DagModel.is_active == True,
-            DagModel.is_paused == False,
-        )
-        .group_by(
-            DagModel.dag_id,
-            "unmonitored",
-        )
-    )
 
-    for r in query:
-        yield r
+        for r in query:
+            yield r
 
 
 class MetricsCollector(object):
@@ -591,14 +622,6 @@ class MetricsCollector(object):
                 "task_id",
                 "owner",
                 "status",
-                "cadence",
-                "severity",
-                "alert_target",
-                "alert_external_classification",
-                "alert_report_classification",
-                "sla_time",
-                "network",
-                "business",
             ],
         )
         for task in task_info:
@@ -608,14 +631,6 @@ class MetricsCollector(object):
                     task.task_id,
                     task.owners,
                     task.state or MISSING,
-                    task.cadence or MISSING,
-                    task.severity or MISSING,
-                    task.alert_target or MISSING,
-                    task.alert_external_classification or MISSING,
-                    task.alert_report_classification or MISSING,
-                    task.sla_time or MISSING,
-                    "network",
-                    "business",
                 ],
                 task.value,
             )
@@ -656,14 +671,6 @@ class MetricsCollector(object):
                 "dag_id",
                 "owner",
                 "status",
-                "cadence",
-                "severity",
-                "alert_target",
-                "alert_external_classification",
-                "alert_report_classification",
-                "sla_time",
-                "network",
-                "business",
             ],
         )
         for dag in dag_info:
@@ -672,14 +679,6 @@ class MetricsCollector(object):
                     dag.dag_id,
                     dag.owners,
                     dag.state,
-                    dag.cadence or MISSING,
-                    dag.severity or MISSING,
-                    dag.alert_target or MISSING,
-                    dag.alert_external_classification or MISSING,
-                    dag.alert_report_classification or MISSING,
-                    dag.sla_time or MISSING,
-                    "network",
-                    "business",
                 ],
                 dag.count,
             )

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -379,11 +379,17 @@ def get_sla_miss():
                     "insert": insert,
                 }
 
+            alert_name = alert.alert_name
+            if alert_name is None:
+                alert_name = alert.dag_id
+                if alert.task_id:
+                    alert_name += "." + alert.task_id
+
             yield {
                 "dag_id": alert.dag_id,
                 "task_id": alert.task_id or MISSING,
                 "affected_pipeline": alert.affected_pipeline or MISSING,
-                "alert_name": alert.alert_name or alert.dag_id,
+                "alert_name": alert_name,
                 "alert_target": alert.alert_target or MISSING,
                 "group_title": alert.group_title or alert.alert_name,
                 "inhibit_rule": alert.inhibit_rule or MISSING,

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -31,8 +31,7 @@ CANARY_DAG = "canary_dag"
 RETENTION_TIME = os.environ.get("PROMETHEUS_METRICS_DAYS", 21)
 TIMEZONE = conf.get("core", "default_timezone")
 TIMEZONE_LA = "America/Los_Angeles"
-MISSING = "missing"
-DEFAULT_LINK = "https://openmail.atlassian.net/wiki/spaces/ETL/pages/2132508806/Help"
+MISSING = "n/a"
 
 
 @contextmanager
@@ -388,7 +387,7 @@ def get_sla_miss():
                 "alert_target": alert.alert_target or MISSING,
                 "group_title": alert.group_title or alert.alert_name,
                 "inhibit_rule": alert.inhibit_rule or MISSING,
-                "link": alert.link or DEFAULT_LINK,
+                "link": alert.link or MISSING,
                 "sla_interval": alert.sla_interval,
                 "sla_miss": sla_miss,
                 "sla_time": alert.sla_time or MISSING,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ marshmallow==3.12.1
 numpy==1.20.3
 pendulum==2.1.2
 prometheus_client==0.8.0
+python-dateutil==2.8.2
 pytimeparse==1.1.8


### PR DESCRIPTION
# Summary [DATAOPS-158](https://openmail.atlassian.net/browse/DATAOPS-158)

1. Combine sla miss functions. 
2. Fix firing-resolved-firing
3. Update table schemas
4. Optimize logic
5. Remove not so useful functions/metrics

# Deployment Instructions

1. Table: `ddns_delay_alert_metadata` 
```
create table ddns_delay_alert_metadata
as
select *
from delay_alert_metadata;

alter table ddns_delay_alert_metadata
rename alert_external_classification to alert_name;

alter table ddns_delay_alert_metadata
rename group_business_line to group_title;

alter table ddns_delay_alert_metadata
drop latest_successful_run
,drop alert_report_classification
,drop group_pagerduty
,drop severity;
```
2. Table: `ddns_delay_auxiliary_info`
```
create table ddns_delay_alert_auxiliary_info
as 
select *
from ddns_latest_successful_run;

alter table ddns_delay_alert_auxiliary_info
rename execution_date to latest_successful_run;

alter table ddns_delay_alert_auxiliary_info
add column latest_sla_miss_state boolean;
```
3. Tag this version
4. Continue https://github.com/Openmail/system1/pull/51128