### PR TITLE
DATAOPS-158-2: Align python-dateutil version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ marshmallow==3.12.1
 numpy==1.20.3
 pendulum==2.1.2
 prometheus_client==0.8.0
-python-dateutil==2.8.2
+python-dateutil==2.8.1
 pytimeparse==1.1.8


### PR DESCRIPTION
# Summary

1. https://etl_jenkins.system1.com/job/build/job/build_airflow/406/console

```
23:56:28 [91mERROR: Cannot install -r /tmp/requirements.txt (line 8) because these package versions have conflicting dependencies.
23:56:28 [0m
23:56:28 The conflict is caused by:
23:56:28     airflow-prometheus-exporter 1.0.7 depends on python-dateutil==2.8.2
23:56:28     The user requested (constraint) python-dateutil==2.8.1
```

# Deployment Instructions

1. merge and tag
2. update exporter version in airflow requirements.etl.txt